### PR TITLE
devise token authの認証メソッドの追加。

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::AuthController < DeviseTokenAuth::SessionsController
+  def destroy
+    # 認証ヘッダーが存在するかチェック
+    unless request.headers["access-token"] && request.headers["client"] && request.headers["uid"]
+      render json: { error: "認証ヘッダーが不足しています" }, status: :unauthorized
+      return
+    end
+
+    # ユーザーが認証されているかチェック
+    unless current_api_v1_user
+      render json: { error: "無効な認証トークンです" }, status: :unauthorized
+      return
+    end
+
+    # 正常なログアウト処理
+    current_api_v1_user.tokens.delete(request.headers["client"])
+    current_api_v1_user.save!
+
+    render json: { success: true, message: "ログアウトしました" }, status: :ok
+  end
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -5,7 +5,17 @@ class Api::V1::BaseApiController < ApplicationController
   private
 
     def current_user
-      # 仮実装: usersテーブルの一番初めのユーザーを返す
-      User.first
+      # devise_token_authの認証されたユーザーを返す
+      current_api_v1_user
+    end
+
+    def authenticate_user!
+      # devise_token_authの認証メソッドを使用
+      authenticate_api_v1_user!
+    end
+
+    def user_signed_in?
+      # devise_token_authの認証状態を確認
+      current_api_v1_user.present?
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        sessions: "api/v1/auth",
+      }
       resources :articles
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,9 +64,4 @@ RSpec.configure do |config|
   def json_response
     JSON.parse(response.body)
   end
-
-  # テスト用の認証スキップ設定
-  config.before(:each, type: :request) do
-    allow_any_instance_of(Api::V1::BaseApiController).to receive(:authenticate_api_v1_user!).and_return(true)
-  end
 end


### PR DESCRIPTION
ログインに必要なヘッダー情報を渡すように修正した。